### PR TITLE
added logger package

### DIFF
--- a/logger/error.go
+++ b/logger/error.go
@@ -1,0 +1,30 @@
+package logger
+
+import (
+	"fmt"
+
+	"github.com/juju/errgo"
+)
+
+var (
+	maskAny = errgo.MaskFunc(errgo.Any)
+)
+
+func maskAnyf(err error, f string, v ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	f = fmt.Sprintf("%s: %s", err.Error(), f)
+	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
+	newErr.(*errgo.Err).SetLocation(1)
+
+	return newErr
+}
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,54 @@
+package logger
+
+import (
+	"os"
+	"time"
+
+	kitlog "github.com/go-kit/kit/log"
+)
+
+// Config represents the configuration used to create a new logger.
+type Config struct {
+	// Settings.
+	TimestampFormatter kitlog.Valuer
+}
+
+// DefaultConfig provides a default configuration to create a new logger by best
+// effort.
+func DefaultConfig() Config {
+	return Config{
+		// Settings.
+		TimestampFormatter: func() interface{} {
+			return time.Now().UTC().Format("06-01-02 15:04:05.000")
+		},
+	}
+}
+
+// New creates a new configured logger.
+func New(config Config) (Logger, error) {
+	// Settings.
+	if config.TimestampFormatter == nil {
+		return nil, maskAnyf(invalidConfigError, "timestamp formatter must not be empty")
+	}
+
+	kitLogger := kitlog.NewJSONLogger(kitlog.NewSyncWriter(os.Stdout))
+	kitLogger = kitlog.NewContext(kitLogger).With(
+		"ts", config.TimestampFormatter,
+		"caller", kitlog.DefaultCaller,
+	)
+
+	newLogger := &logger{
+		Logger: kitLogger,
+	}
+
+	return newLogger, nil
+}
+
+// Logger implements a logging interface used to log messages.
+type logger struct {
+	Logger kitlog.Logger
+}
+
+func (l *logger) Log(keyvals ...interface{}) error {
+	return l.Logger.Log(keyvals...)
+}

--- a/logger/spec.go
+++ b/logger/spec.go
@@ -1,0 +1,5 @@
+package logger
+
+type Logger interface {
+	Log(keyvals ...interface{}) error
+}


### PR DESCRIPTION
This PR adds the logger package of the microkit. This is basically an abstraction of the go-kit logger which is intended to be used in our microservices. Currently the build fails because I separated PRs to not have one giant PR. 