### PR TITLE
Simplify error package

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/microkit/command/daemon"
 	"github.com/giantswarm/microkit/command/version"
+	microerror "github.com/giantswarm/microkit/error"
 	"github.com/giantswarm/microkit/logger"
 	"github.com/giantswarm/microkit/server"
 )
@@ -53,7 +54,7 @@ func New(config Config) (Command, error) {
 
 		daemonCommand, err = daemon.New(daemonConfig)
 		if err != nil {
-			return nil, maskAny(err)
+			return nil, microerror.MaskAny(err)
 		}
 	}
 
@@ -69,7 +70,7 @@ func New(config Config) (Command, error) {
 
 		versionCommand, err = version.New(versionConfig)
 		if err != nil {
-			return nil, maskAny(err)
+			return nil, microerror.MaskAny(err)
 		}
 	}
 

--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -8,6 +8,7 @@ import (
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 
+	microerror "github.com/giantswarm/microkit/error"
 	"github.com/giantswarm/microkit/logger"
 	"github.com/giantswarm/microkit/server"
 )
@@ -33,10 +34,10 @@ func DefaultConfig() Config {
 func New(config Config) (Command, error) {
 	// Dependencies.
 	if config.Logger == nil {
-		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "logger must not be empty")
 	}
 	if config.ServerFactory == nil {
-		return nil, maskAnyf(invalidConfigError, "server factory must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "server factory must not be empty")
 	}
 
 	config.Logger = kitlog.NewContext(config.Logger).With("package", "command/daemon")

--- a/command/daemon/error.go
+++ b/command/daemon/error.go
@@ -1,32 +1,8 @@
 package daemon
 
 import (
-	"fmt"
-
 	"github.com/juju/errgo"
 )
-
-var (
-	maskAny = errgo.MaskFunc(errgo.Any)
-)
-
-func maskAnyf(err error, f string, v ...interface{}) error {
-	if err == nil {
-		return nil
-	}
-
-	f = fmt.Sprintf("%s: %s", err.Error(), f)
-	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
-	newErr.(*errgo.Err).SetLocation(1)
-
-	return newErr
-}
-
-func panicOnError(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
 
 var invalidConfigError = errgo.New("invalid config")
 

--- a/command/daemon/flag.go
+++ b/command/daemon/flag.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	microerror "github.com/giantswarm/microkit/error"
 )
 
 // Flags is the global flag structure used to apply certain configuration to it.
@@ -37,7 +39,7 @@ func MergeFlags(fs *pflag.FlagSet) error {
 			// In case there is no config file given we simply go ahead to check the
 			// process environment.
 		} else {
-			return maskAny(err)
+			return microerror.MaskAny(err)
 		}
 	}
 

--- a/command/error.go
+++ b/command/error.go
@@ -1,32 +1,8 @@
 package command
 
 import (
-	"fmt"
-
 	"github.com/juju/errgo"
 )
-
-var (
-	maskAny = errgo.MaskFunc(errgo.Any)
-)
-
-func maskAnyf(err error, f string, v ...interface{}) error {
-	if err == nil {
-		return nil
-	}
-
-	f = fmt.Sprintf("%s: %s", err.Error(), f)
-	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
-	newErr.(*errgo.Err).SetLocation(1)
-
-	return newErr
-}
-
-func panicOnError(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
 
 var invalidConfigError = errgo.New("invalid config")
 

--- a/command/version/command.go
+++ b/command/version/command.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
+
+	microerror "github.com/giantswarm/microkit/error"
 )
 
 // Config represents the configuration used to create a new version command.
@@ -34,19 +36,19 @@ func DefaultConfig() Config {
 func New(config Config) (Command, error) {
 	// Settings.
 	if config.Description == "" {
-		return nil, maskAnyf(invalidConfigError, "description commit must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "description commit must not be empty")
 	}
 	if config.GitCommit == "" {
-		return nil, maskAnyf(invalidConfigError, "git commit must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "git commit must not be empty")
 	}
 	if config.Name == "" {
-		return nil, maskAnyf(invalidConfigError, "name must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "name must not be empty")
 	}
 	if config.ProjectVersion == "" {
-		return nil, maskAnyf(invalidConfigError, "project version must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "project version must not be empty")
 	}
 	if config.Source == "" {
-		return nil, maskAnyf(invalidConfigError, "name must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "name must not be empty")
 	}
 
 	newCommand := &command{

--- a/command/version/error.go
+++ b/command/version/error.go
@@ -1,32 +1,8 @@
 package version
 
 import (
-	"fmt"
-
 	"github.com/juju/errgo"
 )
-
-var (
-	maskAny = errgo.MaskFunc(errgo.Any)
-)
-
-func maskAnyf(err error, f string, v ...interface{}) error {
-	if err == nil {
-		return nil
-	}
-
-	f = fmt.Sprintf("%s: %s", err.Error(), f)
-	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
-	newErr.(*errgo.Err).SetLocation(1)
-
-	return newErr
-}
-
-func panicOnError(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
 
 var invalidConfigError = errgo.New("invalid config")
 

--- a/error/error.go
+++ b/error/error.go
@@ -1,0 +1,39 @@
+// Package error provides project wide helper functions for a more convenient
+// and efficient error handling.
+package error
+
+import (
+	"fmt"
+
+	"github.com/juju/errgo"
+)
+
+var (
+	// MaskAny is a simple error masker. Masked errors act as tracers within the
+	// source code. Inspecting an masked error shows where the error was passed
+	// through within the code base. This is gold for debugging and bug huntin.
+	MaskAny = errgo.MaskFunc(errgo.Any)
+)
+
+// MaskAnyf is like MaskAny. In addition to that it takes a format string and
+// variadic arguments like fmt.Sprintf. The format string and variadic arguments
+// are used to annotate the given errgo error.
+func MaskAnyf(err error, f string, v ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	f = fmt.Sprintf("%s: %s", err.Error(), f)
+	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
+	newErr.(*errgo.Err).SetLocation(1)
+
+	return newErr
+}
+
+// PanicOnError panics in case the given error is not nil. Otherwise it will do
+// nothing.
+func PanicOnError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/logger/error.go
+++ b/logger/error.go
@@ -1,26 +1,8 @@
 package logger
 
 import (
-	"fmt"
-
 	"github.com/juju/errgo"
 )
-
-var (
-	maskAny = errgo.MaskFunc(errgo.Any)
-)
-
-func maskAnyf(err error, f string, v ...interface{}) error {
-	if err == nil {
-		return nil
-	}
-
-	f = fmt.Sprintf("%s: %s", err.Error(), f)
-	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
-	newErr.(*errgo.Err).SetLocation(1)
-
-	return newErr
-}
 
 var invalidConfigError = errgo.New("invalid config")
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	kitlog "github.com/go-kit/kit/log"
+
+	microerror "github.com/giantswarm/microkit/error"
 )
 
 // Config represents the configuration used to create a new logger.
@@ -28,7 +30,7 @@ func DefaultConfig() Config {
 func New(config Config) (Logger, error) {
 	// Settings.
 	if config.TimestampFormatter == nil {
-		return nil, maskAnyf(invalidConfigError, "timestamp formatter must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "timestamp formatter must not be empty")
 	}
 
 	kitLogger := kitlog.NewJSONLogger(kitlog.NewSyncWriter(os.Stdout))

--- a/server/error.go
+++ b/server/error.go
@@ -1,26 +1,8 @@
 package server
 
 import (
-	"fmt"
-
 	"github.com/juju/errgo"
 )
-
-var (
-	maskAny = errgo.MaskFunc(errgo.Any)
-)
-
-func maskAnyf(err error, f string, v ...interface{}) error {
-	if err == nil {
-		return nil
-	}
-
-	f = fmt.Sprintf("%s: %s", err.Error(), f)
-	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
-	newErr.(*errgo.Err).SetLocation(1)
-
-	return newErr
-}
 
 var invalidConfigError = errgo.New("invalid config")
 

--- a/server/response_writer.go
+++ b/server/response_writer.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"net/http"
+
+	microerror "github.com/giantswarm/microkit/error"
 )
 
 // ResponseWriterConfig represents the configuration used to create a new
@@ -26,10 +28,10 @@ func DefaultResponseWriterConfig() ResponseWriterConfig {
 func NewResponseWriter(config ResponseWriterConfig) (ResponseWriter, error) {
 	// Settings.
 	if config.ResponseWriter == nil {
-		return nil, maskAnyf(invalidConfigError, "response writer must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "response writer must not be empty")
 	}
 	if config.StatusCode == 0 {
-		return nil, maskAnyf(invalidConfigError, "status code must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "status code must not be empty")
 	}
 
 	newResponseWriter := &responseWriter{

--- a/server/server.go
+++ b/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tylerb/graceful"
 	"golang.org/x/net/context"
 
+	microerror "github.com/giantswarm/microkit/error"
 	"github.com/giantswarm/microkit/logger"
 )
 
@@ -52,26 +53,26 @@ func DefaultConfig() Config {
 func New(config Config) (Server, error) {
 	// Dependencies.
 	if config.Endpoints == nil {
-		return nil, maskAnyf(invalidConfigError, "endpoints must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "endpoints must not be empty")
 	}
 	if config.ErrorEncoder == nil {
-		return nil, maskAnyf(invalidConfigError, "error encoder must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "error encoder must not be empty")
 	}
 	if config.Logger == nil {
-		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "logger must not be empty")
 	}
 	if config.RequestFuncs == nil {
-		return nil, maskAnyf(invalidConfigError, "request funcs must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "request funcs must not be empty")
 	}
 
 	// Settings.
 	if config.ListenAddress == "" {
-		return nil, maskAnyf(invalidConfigError, "listen address must not be empty")
+		return nil, microerror.MaskAnyf(invalidConfigError, "listen address must not be empty")
 	}
 
 	listenURL, err := url.Parse(config.ListenAddress)
 	if err != nil {
-		return nil, maskAnyf(invalidConfigError, err.Error())
+		return nil, microerror.MaskAnyf(invalidConfigError, err.Error())
 	}
 
 	newServer := &server{


### PR DESCRIPTION
As discussed I introduced a separate error package to prevent some copy/paste code. I am somehow not amazed by this as the benefit of less code is shadowed by additional imports with weird namings and longer lines where the error package methods are used. What do you think? Note that the build fails because https://github.com/giantswarm/microkit/pull/7 is not merged. 