### PR TITLE
removed extra logger wrapper to fix caller

### DIFF
--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -6,7 +6,6 @@ import (
 	"os/signal"
 	"sync"
 
-	kitlog "github.com/go-kit/kit/log"
 	"github.com/spf13/cobra"
 
 	microerror "github.com/giantswarm/microkit/error"
@@ -40,8 +39,6 @@ func New(config Config) (Command, error) {
 	if config.ServerFactory == nil {
 		return nil, microerror.MaskAnyf(invalidConfigError, "server factory must not be empty")
 	}
-
-	config.Logger = kitlog.NewContext(config.Logger).With("package", "command/daemon")
 
 	newCommand := &command{
 		// Internals.

--- a/server/server.go
+++ b/server/server.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	kitendpoint "github.com/go-kit/kit/endpoint"
-	kitlog "github.com/go-kit/kit/log"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -78,14 +77,12 @@ func New(config Config) (Server, error) {
 	}
 
 	newServer := &server{
-		Config: config,
-
 		bootOnce:     sync.Once{},
 		endpoints:    config.Endpoints,
 		errorEncoder: config.ErrorEncoder,
 		httpServer:   nil,
 		listenURL:    listenURL,
-		logger:       kitlog.NewContext(config.Logger).With("package", "server"),
+		logger:       config.Logger,
 		requestFuncs: config.RequestFuncs,
 		shutdownOnce: sync.Once{},
 	}
@@ -95,8 +92,6 @@ func New(config Config) (Server, error) {
 
 // server manages the transport logic and endpoint registration.
 type server struct {
-	Config
-
 	bootOnce     sync.Once
 	endpoints    []Endpoint
 	errorEncoder kithttp.ErrorEncoder

--- a/server/server.go
+++ b/server/server.go
@@ -137,7 +137,7 @@ func (s *server) ErrorEncoder() kithttp.ErrorEncoder {
 	return func(ctx context.Context, err error, w http.ResponseWriter) {
 		s.errorEncoder(ctx, err, w)
 
-		s.Logger.Log("error", fmt.Sprintf("%#v", err))
+		s.logger.Log("error", fmt.Sprintf("%#v", err))
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -211,7 +211,7 @@ func (s *server) NewRouter() *mux.Router {
 			// When it is executed we know all necessary information to instrument the
 			// complete request, including its response status code.
 			defer func(t time.Time) {
-				s.Logger.Log("code", endpointCode, "endpoint", endpointName, "method", endpointMethod, "path", r.URL.Path)
+				s.logger.Log("code", endpointCode, "endpoint", endpointName, "method", endpointMethod, "path", r.URL.Path)
 
 				// At the time this code is executed the status code is properly set. So
 				// we can use it for our instrumentation.


### PR DESCRIPTION
This PR removes the extra wrapping of the logger inside microkit packages. The wrapping causes a weird behaviour of the caller. I anyway wanted to remove the wrapping because the additionally annotated information did not make that much sense, especially not in case the caller works correctly. 

This is the current faulty behaviour. The caller of the first line is correct. The caller of the second is not. We do not emit any logs inside the go-kit package. 
```
{"caller":"github.com/giantswarm/kubernetesd/service/service.go:96","debug":"creating out-cluster config","time":"16-12-16 21:50:24.542"}
{"caller":"github.com/giantswarm/kubernetesd/vendor/github.com/go-kit/kit/log/log.go:86","code":200,"endpoint":"version","method":"get","package":"command/daemon","path":"/","time":"16-12-16 21:50:43.476"}
```

This is how logs look like using the fix of this PR. 
```
{"caller":"github.com/giantswarm/kubernetesd/service/service.go:96","debug":"creating out-cluster config","time":"16-12-16 22:04:06.613"}
{"caller":"github.com/giantswarm/kubernetesd/vendor/github.com/giantswarm/microkit/server/server.go:218","code":200,"endpoint":"version","method":"get","path":"/","time":"16-12-16 22:04:16.147"}
```