### PR TITLE
set default port to 8000

### DIFF
--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -60,7 +60,7 @@ func New(config Config) (Command, error) {
 	newCommand.cobraCommand.PersistentFlags().StringSliceVar(&Flags.Config.Dirs, "config.dirs", []string{"."}, "List of config file directories.")
 	newCommand.cobraCommand.PersistentFlags().StringSliceVar(&Flags.Config.Files, "config.files", []string{"config"}, "List of the config file names. All viper supported extensions can be used.")
 
-	newCommand.cobraCommand.PersistentFlags().StringVar(&Flags.Server.Listen.Address, "server.listen.address", "http://127.0.0.1:8080", "Address used to make the server listen to.")
+	newCommand.cobraCommand.PersistentFlags().StringVar(&Flags.Server.Listen.Address, "server.listen.address", "http://127.0.0.1:8000", "Address used to make the server listen to.")
 
 	return newCommand, nil
 }


### PR DESCRIPTION
This PR aligns the default port with the port used in our Kubernetes environments. Having a little bit more of consistency in here makes it more easy to switch between development and production. 

RFR @giantswarm/team-positive 