### PR TITLE
provide general server codes

### DIFF
--- a/server/codes.go
+++ b/server/codes.go
@@ -1,0 +1,11 @@
+package server
+
+var (
+	CodeResourceCreated       = "RESOURCE_CREATED"
+	CodeResourceUpdated       = "RESOURCE_UPDATED"
+	CodeResourceDeleted       = "RESOURCE_DELETED"
+	CodeResourceNotFound      = "RESOURCE_NOT_FOUND"
+	CodeResourceAlreadyExists = "RESOURCE_ALREADY_EXISTS"
+	CodeInvalidCredentials    = "INVALID_CREDENTIALS"
+	CodePermissionDenied      = "PERMISSION_DENIED"
+)

--- a/server/codes.go
+++ b/server/codes.go
@@ -1,11 +1,19 @@
 package server
 
 var (
-	CodeResourceCreated       = "RESOURCE_CREATED"
-	CodeResourceUpdated       = "RESOURCE_UPDATED"
-	CodeResourceDeleted       = "RESOURCE_DELETED"
-	CodeResourceNotFound      = "RESOURCE_NOT_FOUND"
+	// CodeInvalidCredentials indicates the provided credentials are not valid.
+	CodeInvalidCredentials = "INVALID_CREDENTIALS"
+	// CodePermissionDenied indicates the provided credentials are valid, but the
+	// requested resource requires other permissions.
+	CodePermissionDenied = "PERMISSION_DENIED"
+	// CodeResourceAlreadyExists indicates a resource does already exist.
 	CodeResourceAlreadyExists = "RESOURCE_ALREADY_EXISTS"
-	CodeInvalidCredentials    = "INVALID_CREDENTIALS"
-	CodePermissionDenied      = "PERMISSION_DENIED"
+	// CodeResourceCreated indicates a resource has been created.
+	CodeResourceCreated = "RESOURCE_CREATED"
+	// CodeResourceDeleted indicates a resource has been deleted.
+	CodeResourceDeleted = "RESOURCE_DELETED"
+	// CodeResourceNotFound indicates a resource could not be found.
+	CodeResourceNotFound = "RESOURCE_NOT_FOUND"
+	// CodeResourceUpdated indicates a resource has been updated.
+	CodeResourceUpdated = "RESOURCE_UPDATED"
 )


### PR DESCRIPTION
This PR is to provide general server codes. We need that to fulfil our API specifications. We want to provide response codes and responses messages. These should be the same across our microservices. Note that this is not a complete list and will be modified over time. 