### PR TITLE
expose underlying error for error encoders

### DIFF
--- a/server/response_error.go
+++ b/server/response_error.go
@@ -84,3 +84,7 @@ func (e *responseError) SetCode(code string) {
 func (e *responseError) SetMessage(message string) {
 	e.message = message
 }
+
+func (e *responseError) Underlying() error {
+	return e.underlying
+}

--- a/server/response_error.go
+++ b/server/response_error.go
@@ -86,5 +86,10 @@ func (e *responseError) SetMessage(message string) {
 }
 
 func (e *responseError) Underlying() error {
+	kErr, ok := e.underlying.(kithttp.Error)
+	if ok {
+		return kErr
+	}
+
 	return e.underlying
 }

--- a/server/response_error.go
+++ b/server/response_error.go
@@ -88,7 +88,7 @@ func (e *responseError) SetMessage(message string) {
 func (e *responseError) Underlying() error {
 	kErr, ok := e.underlying.(kithttp.Error)
 	if ok {
-		return kErr
+		return kErr.Err
 	}
 
 	return e.underlying

--- a/server/spec.go
+++ b/server/spec.go
@@ -86,6 +86,8 @@ type ResponseError interface {
 	// SetMessage tracks the given response message for the current response
 	// error. The given response message will be used for response creation.
 	SetMessage(message string)
+	// Underlying returns the actual underlying error.
+	Underlying() error
 }
 
 // ResponseWriter is a wrapper for http.ResponseWriter to track the written

--- a/server/spec.go
+++ b/server/spec.go
@@ -86,7 +86,8 @@ type ResponseError interface {
 	// SetMessage tracks the given response message for the current response
 	// error. The given response message will be used for response creation.
 	SetMessage(message string)
-	// Underlying returns the actual underlying error.
+	// Underlying returns the actual underlying error, which is expected to be of
+	// type kithttp.Error.
 	Underlying() error
 }
 


### PR DESCRIPTION
This PR is to expose the actually underlying error so it can be accessed within the client's configured error encoder. 