### PR TITLE
cleaned server interface by providing config method

### DIFF
--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -82,20 +82,21 @@ func (c *command) Execute(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
-	customServer := c.serverFactory()
-
 	var newServer server.Server
 	{
 		serverConfig := server.DefaultConfig()
 
-		serverConfig.Endpoints = customServer.Endpoints()
-		serverConfig.ErrorEncoder = customServer.ErrorEncoder()
+		// Dependencies.
+		serverConfig.ErrorEncoder = c.serverFactory().Config().ErrorEncoder
+		serverConfig.Logger = c.serverFactory().Config().Logger
+		serverConfig.Router = c.serverFactory().Config().Router
+		serverConfig.TransactionResponder = c.serverFactory().Config().TransactionResponder
+
+		// Settings.
+		serverConfig.Endpoints = c.serverFactory().Config().Endpoints
 		serverConfig.ListenAddress = Flags.Server.Listen.Address
-		serverConfig.Logger = customServer.Logger()
-		serverConfig.RequestFuncs = customServer.RequestFuncs()
-		serverConfig.Router = customServer.Router()
-		serverConfig.ServiceName = customServer.ServiceName()
-		serverConfig.TransactionResponder = customServer.TransactionResponder()
+		serverConfig.RequestFuncs = c.serverFactory().Config().RequestFuncs
+		serverConfig.ServiceName = c.serverFactory().Config().ServiceName
 
 		newServer, err = server.New(serverConfig)
 		if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -34,7 +34,7 @@ func Test_Transaction_NoIDGiven(t *testing.T) {
 		}
 		w := httptest.NewRecorder()
 
-		newServer.Router().ServeHTTP(w, r)
+		newServer.Config().Router.ServeHTTP(w, r)
 
 		if w.Code != http.StatusOK {
 			t.Fatal("expected", http.StatusOK, "got", w.Code)
@@ -67,7 +67,7 @@ func Test_Transaction_NoIDGiven(t *testing.T) {
 		}
 		w := httptest.NewRecorder()
 
-		newServer.Router().ServeHTTP(w, r)
+		newServer.Config().Router.ServeHTTP(w, r)
 
 		if w.Code != http.StatusOK {
 			t.Fatal("expected", http.StatusOK, "got", w.Code)
@@ -115,7 +115,7 @@ func Test_Transaction_IDGiven(t *testing.T) {
 		r.Header.Add(TransactionIDHeader, "my-very-valid-test-transaction-id")
 		w := httptest.NewRecorder()
 
-		newServer.Router().ServeHTTP(w, r)
+		newServer.Config().Router.ServeHTTP(w, r)
 
 		if w.Code != http.StatusOK {
 			t.Fatal("expected", http.StatusOK, "got", w.Code)
@@ -151,7 +151,7 @@ func Test_Transaction_IDGiven(t *testing.T) {
 		r.Header.Add(TransactionIDHeader, "my-very-valid-test-transaction-id")
 		w := httptest.NewRecorder()
 
-		newServer.Router().ServeHTTP(w, r)
+		newServer.Config().Router.ServeHTTP(w, r)
 
 		if w.Code != http.StatusOK {
 			t.Fatal("expected", http.StatusOK, "got", w.Code)
@@ -203,7 +203,7 @@ func Test_Transaction_InvalidIDGiven(t *testing.T) {
 		r.Header.Add(TransactionIDHeader, "--my-invalid-transaction-id--")
 		w := httptest.NewRecorder()
 
-		newServer.Router().ServeHTTP(w, r)
+		newServer.Config().Router.ServeHTTP(w, r)
 
 		if w.Code != http.StatusInternalServerError {
 			t.Fatal("expected", http.StatusInternalServerError, "got", w.Code)

--- a/server/spec.go
+++ b/server/spec.go
@@ -6,10 +6,6 @@ import (
 
 	kitendpoint "github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
-	"github.com/gorilla/mux"
-
-	micrologger "github.com/giantswarm/microkit/logger"
-	microtransaction "github.com/giantswarm/microkit/transaction"
 )
 
 // Endpoint represents the management of transport logic. An endpoint defines
@@ -44,28 +40,10 @@ type Server interface {
 	// Boot registers the configured endpoints and starts the server under the
 	// configured address.
 	Boot()
-	// Endpoints returns the server's configured list of endpoints. These are the
-	// custom endpoints configured by the client.
-	Endpoints() []Endpoint
-	// ErrorEncoder returns the server's error encoder. This wraps the error
-	// encoder configured by the client. Clients should not implement error
-	// logging in here them self. This is done by the server itself. Clients must
-	// not implement error response writing them self. This is done by the server
-	// itself. Duplicated response writing will lead to runtime panics.
-	ErrorEncoder() kithttp.ErrorEncoder
-	Logger() micrologger.Logger
-	// RequestFuncs returns the server's configured list of request functions.
-	// These are the custom request functions configured by the client.
-	RequestFuncs() []kithttp.RequestFunc
-	// Router returns a HTTP handler for the server. The returned router will have
-	// all endpoints registered that are listed in the endpoint collection.
-	Router() *mux.Router
-	// ServiceName returns the name of the micro-service implementing the microkit
-	// server. This is used for logging and instrumentation.
-	ServiceName() string
+	// Config returns the servers configuration as given by the client.
+	Config() Config
 	// Shutdown stops the running server gracefully.
 	Shutdown()
-	TransactionResponder() microtransaction.Responder
 }
 
 // ResponseError is a wrapper for errors passed to the client's error encoder to


### PR DESCRIPTION
This PR eases the client's necessary interface implementations. My next step is to add TLS configuration to the micro server. See also https://github.com/giantswarm/microkit-example/pull/17 where the change is used. 