### PR TITLE
support TLS in micro server

### DIFF
--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -85,6 +85,7 @@ func (c *command) Execute(cmd *cobra.Command, args []string) {
 	var newServer server.Server
 	{
 		serverConfig := c.serverFactory().Config()
+		serverConfig.ListenAddress = Flags.Server.Listen.Address
 		newServer, err = server.New(serverConfig)
 		if err != nil {
 			panic(err)

--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -84,20 +84,7 @@ func (c *command) Execute(cmd *cobra.Command, args []string) {
 
 	var newServer server.Server
 	{
-		serverConfig := server.DefaultConfig()
-
-		// Dependencies.
-		serverConfig.ErrorEncoder = c.serverFactory().Config().ErrorEncoder
-		serverConfig.Logger = c.serverFactory().Config().Logger
-		serverConfig.Router = c.serverFactory().Config().Router
-		serverConfig.TransactionResponder = c.serverFactory().Config().TransactionResponder
-
-		// Settings.
-		serverConfig.Endpoints = c.serverFactory().Config().Endpoints
-		serverConfig.ListenAddress = Flags.Server.Listen.Address
-		serverConfig.RequestFuncs = c.serverFactory().Config().RequestFuncs
-		serverConfig.ServiceName = c.serverFactory().Config().ServiceName
-
+		serverConfig := c.serverFactory().Config()
 		newServer, err = server.New(serverConfig)
 		if err != nil {
 			panic(err)

--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -58,6 +58,9 @@ func New(config Config) (Command, error) {
 	newCommand.cobraCommand.PersistentFlags().StringSliceVar(&Flags.Config.Files, "config.files", []string{"config"}, "List of the config file names. All viper supported extensions can be used.")
 
 	newCommand.cobraCommand.PersistentFlags().StringVar(&Flags.Server.Listen.Address, "server.listen.address", "http://127.0.0.1:8000", "Address used to make the server listen to.")
+	newCommand.cobraCommand.PersistentFlags().StringVar(&Flags.Server.TLS.CAFile, "server.tls.caFile", "", "File path of the TLS root CA file, if any.")
+	newCommand.cobraCommand.PersistentFlags().StringVar(&Flags.Server.TLS.CrtFile, "server.tls.crtFile", "", "File path of the TLS public key file, if any.")
+	newCommand.cobraCommand.PersistentFlags().StringVar(&Flags.Server.TLS.KeyFile, "server.tls.keyFile", "", "File path of the TLS private key file, if any.")
 
 	return newCommand, nil
 }
@@ -86,6 +89,9 @@ func (c *command) Execute(cmd *cobra.Command, args []string) {
 	{
 		serverConfig := c.serverFactory().Config()
 		serverConfig.ListenAddress = Flags.Server.Listen.Address
+		serverConfig.TLSCAFile = Flags.Server.TLS.CAFile
+		serverConfig.TLSCrtFile = Flags.Server.TLS.CrtFile
+		serverConfig.TLSKeyFile = Flags.Server.TLS.KeyFile
 		newServer, err = server.New(serverConfig)
 		if err != nil {
 			panic(err)

--- a/command/daemon/flag.go
+++ b/command/daemon/flag.go
@@ -21,6 +21,11 @@ var Flags = struct {
 		Listen struct {
 			Address string
 		}
+		TLS struct {
+			CAFile  string
+			CrtFile string
+			KeyFile string
+		}
 	}
 }{}
 

--- a/server/server.go
+++ b/server/server.go
@@ -288,11 +288,13 @@ func (s *server) Boot() {
 				if err != nil {
 					panic(err)
 				}
+				s.logger.Log("debug", "running HTTPS server with TLS config")
 				err = s.httpServer.ListenAndServeTLSConfig(tlsConfig)
 				if err != nil {
 					panic(err)
 				}
 			} else {
+				s.logger.Log("debug", "running HTTP server")
 				err := s.httpServer.ListenAndServe()
 				if err != nil {
 					panic(err)
@@ -578,6 +580,7 @@ func (s *server) newTLSConfig() (*tls.Config, error) {
 		if err != nil {
 			return nil, microerror.MaskAny(err)
 		}
+		s.logger.Log("debug", fmt.Sprintf("found TLS root CA file '%s'", s.tlsCAFile))
 		roots.AddCert(c)
 	}
 
@@ -587,7 +590,8 @@ func (s *server) newTLSConfig() (*tls.Config, error) {
 		if err != nil {
 			return nil, microerror.MaskAny(err)
 		}
-		certs = []tls.Certificate{c}
+		s.logger.Log("debug", fmt.Sprintf("found TLS public key file '%s' and private key file '%s'", s.tlsCrtFile, s.tlsKeyFile))
+		certs = append(certs, c)
 	}
 
 	tlsConfig := &tls.Config{


### PR DESCRIPTION
This PR introduces the ability to run HTTPS servers. The usual HTTP server still works. 
```
$ ./microkit-example daemon --server.listen.address=http://127.0.0.1:8000
{"caller":"github.com/giantswarm/microkit-example/vendor/github.com/giantswarm/microkit/server/server.go:297","debug":"running HTTP server","time":"17-02-13 18:29:59.643"}
```

We can now also make the server serve HTTPS with a TLS config as provided by the flags. The cool thing is the flags are built in and we can configure our K8S configmaps quite nicely. 
```
./microkit-example daemon -h
Execute the daemon of the microservice.

Usage:
  microkit-example daemon [flags]

Flags:
      --config.dirs stringSlice        List of config file directories. (default [.])
      --config.files stringSlice       List of the config file names. All viper supported extensions can be used. (default [config])
      --server.listen.address string   Address used to make the server listen to. (default "http://127.0.0.1:8000")
      --server.tls.caFile string       File path of the TLS root CA file, if any.
      --server.tls.crtFile string      File path of the TLS public key file, if any.
      --server.tls.keyFile string      File path of the TLS private key file, if any.
```
```
$ ./microkit-example daemon --server.listen.address=https://127.0.0.1:8000 --server.tls.caFile /Users/xh3b4sd/.kube/certs/g8s-ca.pem --server.tls.crtFile /Users/xh3b4sd/.kube/certs/g8s-crt.pem --server.tls.keyFile /Users/xh3b4sd/.kube/certs/g8s-key.pem
{"caller":"github.com/giantswarm/microkit-example/vendor/github.com/giantswarm/microkit/server/server.go:589","debug":"found TLS root CA file '/Users/xh3b4sd/.kube/certs/g8s-ca.pem'","time":"17-02-13 18:41:46.417"}
{"caller":"github.com/giantswarm/microkit-example/vendor/github.com/giantswarm/microkit/server/server.go:598","debug":"found TLS public key file '/Users/xh3b4sd/.kube/certs/g8s-crt.pem' and private key file '/Users/xh3b4sd/.kube/certs/g8s-key.pem'","time":"17-02-13 18:41:46.418"}
{"caller":"github.com/giantswarm/microkit-example/vendor/github.com/giantswarm/microkit/server/server.go:291","debug":"running HTTPS server with TLS config","time":"17-02-13 18:41:46.418"}
```

Requesting the TLS server responds with the expected version endpoint. Note that curl needs the `-k` flag because the G8S certs are not generated for `127.0.0.1`.
```
$ curl --cacert /Users/xh3b4sd/.kube/certs/g8s-ca.pem --cert /Users/xh3b4sd/.kube/certs/g8s-crt.pem --key /Users/xh3b4sd/.kube/certs/g8s-key.pem https://127.0.0.1:8000 -k
{"description":"This is an example microservice using the microkit framework.","git_commit":"n/a","go_version":"go1.7.2","name":"microkit-example","os_arch":"darwin/amd64","source":"https://github.com/giantswarm/microkit-example"}
```

See also https://github.com/giantswarm/microkit-example/pull/18, which I used to test these changes. 