### PR TITLE
fix default flags and flag initialization

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -3,25 +3,26 @@ package command
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/giantswarm/microkit/command/daemon"
 	"github.com/giantswarm/microkit/command/version"
 	microerror "github.com/giantswarm/microkit/error"
 	"github.com/giantswarm/microkit/logger"
-	"github.com/giantswarm/microkit/server"
 )
 
 // Config represents the configuration used to create a new root command.
 type Config struct {
 	// Dependencies.
 	Logger        logger.Logger
-	ServerFactory func() server.Server
+	ServerFactory daemon.ServerFactory
 
 	// Settings.
 	Description string
 	GitCommit   string
 	Name        string
 	Source      string
+	Viper       *viper.Viper
 }
 
 // DefaultConfig provides a default configuration to create a new root command
@@ -37,6 +38,7 @@ func DefaultConfig() Config {
 		GitCommit:   "",
 		Name:        "",
 		Source:      "",
+		Viper:       viper.New(),
 	}
 }
 
@@ -50,6 +52,7 @@ func New(config Config) (Command, error) {
 
 		daemonConfig.Logger = config.Logger
 		daemonConfig.ServerFactory = config.ServerFactory
+		daemonConfig.Viper = config.Viper
 
 		daemonCommand, err = daemon.New(daemonConfig)
 		if err != nil {

--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/giantswarm/microkit/command/daemon/flag"
 	microerror "github.com/giantswarm/microkit/error"
@@ -16,14 +17,17 @@ import (
 )
 
 var (
-	Flag = flag.New()
+	f = flag.New()
 )
 
 // Config represents the configuration used to create a new daemon command.
 type Config struct {
 	// Dependencies.
 	Logger        logger.Logger
-	ServerFactory func() server.Server
+	ServerFactory ServerFactory
+
+	// Settings.
+	Viper *viper.Viper
 }
 
 // DefaultConfig provides a default configuration to create a new daemon command
@@ -33,6 +37,9 @@ func DefaultConfig() Config {
 		// Dependencies.
 		Logger:        nil,
 		ServerFactory: nil,
+
+		// Settings.
+		Viper: viper.New(),
 	}
 }
 
@@ -45,12 +52,20 @@ func New(config Config) (Command, error) {
 	if config.ServerFactory == nil {
 		return nil, microerror.MaskAnyf(invalidConfigError, "server factory must not be empty")
 	}
+	if config.Viper == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "viper must not be empty")
+	}
 
 	newCommand := &command{
-		// Internals.
-		cobraCommand:  nil,
+		// Dependencies.
 		logger:        config.Logger,
 		serverFactory: config.ServerFactory,
+
+		// Internals.
+		cobraCommand: nil,
+
+		// Settings.
+		viper: config.Viper,
 	}
 
 	newCommand.cobraCommand = &cobra.Command{
@@ -60,22 +75,27 @@ func New(config Config) (Command, error) {
 		Run:   newCommand.Execute,
 	}
 
-	newCommand.cobraCommand.PersistentFlags().StringSlice(Flag.Config.Dirs, []string{"."}, "List of config file directories.")
-	newCommand.cobraCommand.PersistentFlags().StringSlice(Flag.Config.Files, []string{"config"}, "List of the config file names. All viper supported extensions can be used.")
+	newCommand.cobraCommand.PersistentFlags().StringSlice(f.Config.Dirs, []string{"."}, "List of config file directories.")
+	newCommand.cobraCommand.PersistentFlags().StringSlice(f.Config.Files, []string{"config"}, "List of the config file names. All viper supported extensions can be used.")
 
-	newCommand.cobraCommand.PersistentFlags().String(Flag.Server.Listen.Address, "http://127.0.0.1:8000", "Address used to make the server listen to.")
-	newCommand.cobraCommand.PersistentFlags().String(Flag.Server.TLS.CaFile, "", "File path of the TLS root CA file, if any.")
-	newCommand.cobraCommand.PersistentFlags().String(Flag.Server.TLS.CrtFile, "", "File path of the TLS public key file, if any.")
-	newCommand.cobraCommand.PersistentFlags().String(Flag.Server.TLS.KeyFile, "", "File path of the TLS private key file, if any.")
+	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.Address, "http://127.0.0.1:8000", "Address used to make the server listen to.")
+	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.CaFile, "", "File path of the TLS root CA file, if any.")
+	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.CrtFile, "", "File path of the TLS public key file, if any.")
+	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.KeyFile, "", "File path of the TLS private key file, if any.")
 
 	return newCommand, nil
 }
 
 type command struct {
-	// Internals.
-	cobraCommand  *cobra.Command
+	// Dependencies.
 	logger        logger.Logger
-	serverFactory func() server.Server
+	serverFactory ServerFactory
+
+	// Internals.
+	cobraCommand *cobra.Command
+
+	// Settings.
+	viper *viper.Viper
 }
 
 func (c *command) CobraCommand() *cobra.Command {
@@ -83,23 +103,24 @@ func (c *command) CobraCommand() *cobra.Command {
 }
 
 func (c *command) Execute(cmd *cobra.Command, args []string) {
-	v := c.serverFactory().Config().Viper
-
+	// TODO
+	microflag.Parse(c.viper, cmd.Flags())
+	// TODO
 	// Merge the given command line flags with the given environment variables and
 	// the given config files, if any. The merged flags will be applied to the
 	// given viper.
-	err := microflag.Merge(v, cmd.Flags(), v.GetStringSlice(Flag.Config.Dirs), v.GetStringSlice(Flag.Config.Files))
+	err := microflag.Merge(c.viper, cmd.Flags(), c.viper.GetStringSlice(f.Config.Dirs), c.viper.GetStringSlice(f.Config.Files))
 	if err != nil {
 		panic(err)
 	}
 
 	var newServer server.Server
 	{
-		serverConfig := c.serverFactory().Config()
-		serverConfig.ListenAddress = v.GetString(Flag.Server.Listen.Address)
-		serverConfig.TLSCAFile = v.GetString(Flag.Server.TLS.CaFile)
-		serverConfig.TLSCrtFile = v.GetString(Flag.Server.TLS.CrtFile)
-		serverConfig.TLSKeyFile = v.GetString(Flag.Server.TLS.KeyFile)
+		serverConfig := c.serverFactory(c.viper).Config()
+		serverConfig.ListenAddress = c.viper.GetString(f.Server.Listen.Address)
+		serverConfig.TLSCAFile = c.viper.GetString(f.Server.TLS.CaFile)
+		serverConfig.TLSCrtFile = c.viper.GetString(f.Server.TLS.CrtFile)
+		serverConfig.TLSKeyFile = c.viper.GetString(f.Server.TLS.KeyFile)
 		newServer, err = server.New(serverConfig)
 		if err != nil {
 			panic(err)

--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -103,9 +103,11 @@ func (c *command) CobraCommand() *cobra.Command {
 }
 
 func (c *command) Execute(cmd *cobra.Command, args []string) {
-	// TODO
+	// We have to parse the flags given via command line first. Only that way we
+	// are able to use the flag configuration for the location of configuration
+	// directories and files in the next step below.
 	microflag.Parse(c.viper, cmd.Flags())
-	// TODO
+
 	// Merge the given command line flags with the given environment variables and
 	// the given config files, if any. The merged flags will be applied to the
 	// given viper.

--- a/command/daemon/spec.go
+++ b/command/daemon/spec.go
@@ -2,7 +2,12 @@ package daemon
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/giantswarm/microkit/server"
 )
+
+type ServerFactory func(v *viper.Viper) server.Server
 
 // Command represents the daemon command for any microservice.
 type Command interface {

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -2,6 +2,9 @@ package flag
 
 import (
 	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 func Test_toCase(t *testing.T) {
@@ -130,6 +133,31 @@ func Test_Init(t *testing.T) {
 		if s != e {
 			t.Fatal("expected", e, "got", s)
 		}
+	}
+}
+
+func Test_Parse(t *testing.T) {
+	f := testFlag{}
+	Init(&f)
+
+	v := viper.New()
+
+	fs := pflag.NewFlagSet("test-flag-set", pflag.ContinueOnError)
+	expectedAddress := "http://127.0.0.1:8000"
+	fs.String(f.Server.Listen.Address, expectedAddress, "Test help usage.")
+	expectedFoo := 74
+	fs.Int(f.Foo, expectedFoo, "Test help usage.")
+
+	Parse(v, fs)
+
+	address := v.GetString(f.Server.Listen.Address)
+	if address != expectedAddress {
+		t.Fatal("expected", expectedAddress, "got", address)
+	}
+
+	foo := v.GetInt(f.Foo)
+	if foo != expectedFoo {
+		t.Fatal("expected", expectedFoo, "got", foo)
 	}
 }
 


### PR DESCRIPTION
In Kubernetesd I noticed that flag defaults had not be propagated. This bug was introduced by me in the recent update of the configuration management. Here I provide a fix plus tests. See also https://github.com/giantswarm/kubernetesd/pull/71 where I tested the result manually. 