### PR TITLE
etcd version clarification

### DIFF
--- a/storage/etcd/service.go
+++ b/storage/etcd/service.go
@@ -1,4 +1,4 @@
-// Package etcd provides a service that implements an etcd storage.
+// Package etcd provides a service that implements an etcd storage, using the etcd v3 protocol.
 package etcd
 
 import (


### PR DESCRIPTION
`etcdv2` is for v2, so it's not quite intuitive that `etcd` is for v3 (and not v1)