### PR TITLE
write default response body in error encoder if not already written

### DIFF
--- a/server/codes.go
+++ b/server/codes.go
@@ -1,6 +1,8 @@
 package server
 
 var (
+	// CodeFail indicates the requested action failed.
+	CodeFailure = "FAILURE"
 	// CodeInvalidCredentials indicates the provided credentials are not valid.
 	CodeInvalidCredentials = "INVALID_CREDENTIALS"
 	// CodePermissionDenied indicates the provided credentials are valid, but the
@@ -18,6 +20,8 @@ var (
 	CodeResourceNotFound = "RESOURCE_NOT_FOUND"
 	// CodeResourceUpdated indicates a resource has been updated.
 	CodeResourceUpdated = "RESOURCE_UPDATED"
+	// CodeSuccess indicates the requested action successed.
+	CodeSuccess = "SUCCESS"
 	// CodeUnknownAttribute indicates the provided data structure contains
 	// unexpected fields.
 	CodeUnknownAttribute = "UNKNOWN_ATTRIBUTE"

--- a/server/response_writer.go
+++ b/server/response_writer.go
@@ -41,6 +41,9 @@ func NewResponseWriter(config ResponseWriterConfig) (ResponseWriter, error) {
 	}
 
 	newResponseWriter := &responseWriter{
+		// Internals.
+		hasWritten: false,
+
 		// Settings.
 		bodyBuffer:     config.BodyBuffer,
 		responseWriter: config.ResponseWriter,
@@ -51,6 +54,9 @@ func NewResponseWriter(config ResponseWriterConfig) (ResponseWriter, error) {
 }
 
 type responseWriter struct {
+	// Internals.
+	hasWritten bool
+
 	// Settings.
 	bodyBuffer     *bytes.Buffer
 	responseWriter http.ResponseWriter
@@ -59,6 +65,10 @@ type responseWriter struct {
 
 func (rw *responseWriter) BodyBuffer() *bytes.Buffer {
 	return rw.bodyBuffer
+}
+
+func (rw *responseWriter) HasWritten() bool {
+	return rw.hasWritten
 }
 
 func (rw *responseWriter) Header() http.Header {
@@ -70,6 +80,8 @@ func (rw *responseWriter) StatusCode() int {
 }
 
 func (rw *responseWriter) Write(b []byte) (int, error) {
+	rw.hasWritten = true
+
 	_, err := rw.bodyBuffer.Write(b)
 	if err != nil {
 		return 0, microerror.MaskAny(err)

--- a/server/server.go
+++ b/server/server.go
@@ -242,7 +242,7 @@ func (s *server) Boot() {
 						return
 					}
 
-					responseWriter, err := s.newResponseWriter(w, r)
+					responseWriter, err := s.newResponseWriter(w)
 					if err != nil {
 						s.newErrorEncoderWrapper()(ctx, err, w)
 						return
@@ -365,11 +365,16 @@ func (s *server) newErrorEncoderWrapper() kithttp.ErrorEncoder {
 			}
 		}
 
+		rw, err := s.newResponseWriter(w)
+		if err != nil {
+			panic(err)
+		}
+
 		// Run the custom error encoder. This is used to let the implementing
 		// microservice do something with errors occured during runtime. Things like
-		// writing specific HTTP status codes to the given response writer can be
-		// done.
-		s.errorEncoder(ctx, responseError, w)
+		// writing specific HTTP status codes to the given response writer or
+		// writing data to the response body can be done.
+		s.errorEncoder(ctx, responseError, rw)
 
 		// Log the error and its errgo trace. This is really useful for debugging.
 		errDomain := errorDomain(serverError)
@@ -382,12 +387,15 @@ func (s *server) newErrorEncoderWrapper() kithttp.ErrorEncoder {
 		// general system health.
 		errorTotal.WithLabelValues(errDomain).Inc()
 
-		// Write the actual response body.
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"code":  responseError.Code(),
-			"error": responseError.Message(),
-			"from":  s.serviceName,
-		})
+		// Write the actual response body in case no response was already written
+		// inside the error encoder.
+		if !rw.HasWritten() {
+			json.NewEncoder(rw).Encode(map[string]interface{}{
+				"code":  responseError.Code(),
+				"error": responseError.Message(),
+				"from":  s.serviceName,
+			})
+		}
 	}
 }
 
@@ -573,7 +581,7 @@ func (s *server) newRequestContext(w http.ResponseWriter, r *http.Request) (cont
 // inject it into the called http.Handler so it can track the status code we are
 // interested in. It will help us gathering the response status code after it
 // was written by the underlying http.ResponseWriter.
-func (s *server) newResponseWriter(w http.ResponseWriter, r *http.Request) (ResponseWriter, error) {
+func (s *server) newResponseWriter(w http.ResponseWriter) (ResponseWriter, error) {
 	responseConfig := DefaultResponseWriterConfig()
 	responseConfig.ResponseWriter = w
 	responseWriter, err := NewResponseWriter(responseConfig)

--- a/server/spec.go
+++ b/server/spec.go
@@ -81,6 +81,9 @@ type ResponseWriter interface {
 	// BodyBuffer returns the buffer which is used to track the bytes being
 	// written to the response.
 	BodyBuffer() *bytes.Buffer
+	// HasWritten expresses whether the underlying response writer has already
+	// written anything to the response body.
+	HasWritten() bool
 	// Header is only a wrapper around http.ResponseWriter.Header.
 	Header() http.Header
 	// StatusCode returns either the default status code of the one that was


### PR DESCRIPTION
This PR provides a way to write a customized response body inside the custom error handler. The default response body will be written if there is no body written before. 