### PR TITLE
Renaming transaction ID header to X-Idempotency-Key

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -546,7 +546,7 @@ func (s *server) newNotFoundHandler() http.Handler {
 }
 
 // newRequestContext creates a new request context and enriches it with request
-// relevant information. E.g. here we put the HTTP X-Transaction-ID header into
+// relevant information. E.g. here we put the HTTP X-Idempotency-Key header into
 // the request context, if any. We also check if there is a transaction response
 // already tracked for the given transaction ID. This information is then stored
 // within the given request context as well. Note that we initialize the

--- a/server/transaction.go
+++ b/server/transaction.go
@@ -5,9 +5,9 @@ import (
 )
 
 const (
-	// TransactionIDHeader is the canonical representation of the transaction ID
-	// HTTP header field.
-	TransactionIDHeader = "X-Transaction-ID"
+	// TransactionIDHeader is the canonical representation of the
+	// HTTP header field representing the transaction ID
+	TransactionIDHeader = "X-Idempotency-Key"
 )
 
 var (


### PR DESCRIPTION
As we are renaming the concept of "transactions" to "idempotency" to avoid confusion with the ACID term, we change the HTTP header used for this as well here.

Before: `X-Transaction-ID`

After: `X-Idempotency-Key`