### PR TITLE
add Decorate method

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -64,6 +64,10 @@ type logger struct {
 	Logger kitlog.Logger
 }
 
+func (l *logger) Decorate(keyvals ...interface{}) {
+	l.Logger = kitlog.NewContext(l.Logger).With(keyvals...)
+}
+
 func (l *logger) Log(keyvals ...interface{}) error {
 	return l.Logger.Log(keyvals...)
 }

--- a/logger/spec.go
+++ b/logger/spec.go
@@ -3,6 +3,9 @@ package logger
 // Logger is a simple interface describing services that emit messages to gather
 // certain runtime information.
 type Logger interface {
+	// Decorate takes a sequence of alternating key/value pairs which are used to
+	// decorate the log message.
+	Decorate(v ...interface{})
 	// Log takes a sequence of alternating key/value pairs which are used to
 	// create the log message structure.
 	Log(v ...interface{}) error


### PR DESCRIPTION
Allows users of the library to add context to their log messages.

Uses `kitlog`'s [`With`](https://github.com/go-kit/kit/blob/f66b0e13579bfc5a48b9e2a94b1209c107ea1f41/log/log.go#L90) under the hood.

Useful for example in the operator, to only have to specify the cluster name once:

```
s.logger.Decorate("cluster_name", cluster.Name)
```

Towards https://github.com/giantswarm/aws-operator/issues/274.