### PR TITLE
Fix micrologger import

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/giantswarm/micrologger"
 	kitendpoint "github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
@@ -22,7 +23,6 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/microkit/logger"
-	micrologger "github.com/giantswarm/microkit/logger"
 	"github.com/giantswarm/microkit/tls"
 	"github.com/giantswarm/microkit/transaction"
 	microtransaction "github.com/giantswarm/microkit/transaction"


### PR DESCRIPTION
Fixes a problem compiling azure-operator with the latest vendor updates. There was a compile error about With being missing from the micrologger interface.