### PR TITLE
added flag to cofnigure access logging, disabled by default

### DIFF
--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -79,6 +79,7 @@ func New(config Config) (Command, error) {
 	newCommand.cobraCommand.PersistentFlags().StringSlice(f.Config.Files, []string{"config"}, "List of the config file names. All viper supported extensions can be used.")
 
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.Address, "http://127.0.0.1:8000", "Address used to make the server listen to.")
+	newCommand.cobraCommand.PersistentFlags().Bool(f.Server.Log.Access, false, "Whether to emit logs for each requested route.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.CaFile, "", "File path of the TLS root CA file, if any.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.CrtFile, "", "File path of the TLS public key file, if any.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.KeyFile, "", "File path of the TLS private key file, if any.")
@@ -119,10 +120,13 @@ func (c *command) Execute(cmd *cobra.Command, args []string) {
 	var newServer server.Server
 	{
 		serverConfig := c.serverFactory(c.viper).Config()
+
+		serverConfig.LogAccess = c.viper.GetBool(f.Server.Log.Access)
 		serverConfig.ListenAddress = c.viper.GetString(f.Server.Listen.Address)
 		serverConfig.TLSCAFile = c.viper.GetString(f.Server.TLS.CaFile)
 		serverConfig.TLSCrtFile = c.viper.GetString(f.Server.TLS.CrtFile)
 		serverConfig.TLSKeyFile = c.viper.GetString(f.Server.TLS.KeyFile)
+
 		newServer, err = server.New(serverConfig)
 		if err != nil {
 			panic(err)

--- a/command/daemon/flag/server/log/log.go
+++ b/command/daemon/flag/server/log/log.go
@@ -1,0 +1,5 @@
+package log
+
+type Log struct {
+	Access string
+}

--- a/command/daemon/flag/server/server.go
+++ b/command/daemon/flag/server/server.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"github.com/giantswarm/microkit/command/daemon/flag/server/listen"
+	"github.com/giantswarm/microkit/command/daemon/flag/server/log"
 	"github.com/giantswarm/microkit/command/daemon/flag/server/tls"
 )
 
 type Server struct {
 	Listen listen.Listen
+	Log    log.Log
 	TLS    tls.TLS
 }


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/1825.

There is now an additional flag. Access logging is now disabled by default. See https://github.com/giantswarm/kvm-operator/pull/176. 
```
$ kvm-operator daemon -h
Execute the daemon of the microservice.

Usage:
  kvm-operator daemon [flags]

Flags:
      --config.dirs strings                     List of config file directories. (default [.])
      --config.files strings                    List of the config file names. All viper supported extensions can be used. (default [config])
  -h, --help                                    help for daemon
      --server.listen.address string            Address used to make the server listen to. (default "http://127.0.0.1:8000")
      --server.log.access                       Whether to emit logs for each requested route.
      --server.tls.cafile string                File path of the TLS root CA file, if any.
      --server.tls.crtfile string               File path of the TLS public key file, if any.
      --server.tls.keyfile string               File path of the TLS private key file, if any.
      --service.kubernetes.address string       Address used to connect to Kubernetes. When empty in-cluster config is created. (default "http://127.0.0.1:6443")
      --service.kubernetes.incluster            Whether to use the in-cluster config to authenticate with Kubernetes.
      --service.kubernetes.tls.cafile string    Certificate authority file path to use to authenticate with Kubernetes.
      --service.kubernetes.tls.crtfile string   Certificate file path to use to authenticate with Kubernetes.
      --service.kubernetes.tls.keyfile string   Key file path to use to authenticate with Kubernetes.
```

The new flag enables the access logging. 
```
$ kvm-operator daemon --server.log.access
```