### PR TITLE
Add too many requests code.

### DIFF
--- a/server/codes.go
+++ b/server/codes.go
@@ -22,6 +22,8 @@ var (
 	CodeResourceUpdated = "RESOURCE_UPDATED"
 	// CodeSuccess indicates the requested action successed.
 	CodeSuccess = "SUCCESS"
+	// CodeTooManyRequests indicates the client is making too many requests.
+	CodeTooManyRequests = "TOO_MANY_REQUESTS"
 	// CodeImmutableAttribute indicates the provided data structure contains
 	// fields that are immutable.
 	CodeImmutableAttribute = "IMMUTABLE_ATTRIBUTE"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/2173

We can then let clients know that the reason their attemtps are failing are due to request throttling.
This lets us give some feedback to the user and a better overall UX.

Adding this code was debatable so consider this also a place to debate.