### PR TITLE
Add account expired code.

### DIFF
--- a/server/codes.go
+++ b/server/codes.go
@@ -1,6 +1,8 @@
 package server
 
 var (
+	// CodeAccountExpired indicates the login attempt failed due to an expired account.
+	CodeAccountExpired = "ACCOUNT_EXPIRED"
 	// CodeFailure indicates the requested action failed.
 	CodeFailure = "FAILURE"
 	// CodeInvalidCredentials indicates the provided credentials are not valid.


### PR DESCRIPTION
Will let our auth token endpoint be more specific about why a login attempt failed in the case that the user account is expired.