### PR TITLE
Add an optional flag that spawns a seperate server for the metrics endpoint

### DIFF
--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -60,7 +60,7 @@ func New(config Config) (Command, error) {
 	newCommand.cobraCommand.PersistentFlags().StringSlice(f.Config.Files, []string{"config"}, "List of the config file names. All viper supported extensions can be used.")
 
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.Address, "http://127.0.0.1:8000", "Address used to make the server listen to.")
-	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.MetricsAddress, "http://127.0.0.1:8000", "Optional alternate address to expose metrics on at /metrics. Leave blank to use the address above.")
+	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.MetricsAddress, "", "Optional alternate address to expose metrics on at /metrics. Leave blank to use the address above.")
 	newCommand.cobraCommand.PersistentFlags().Bool(f.Server.Log.Access, false, "Whether to emit logs for each requested route.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.CaFile, "", "File path of the TLS root CA file, if any.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.CrtFile, "", "File path of the TLS public key file, if any.")

--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -60,6 +60,7 @@ func New(config Config) (Command, error) {
 	newCommand.cobraCommand.PersistentFlags().StringSlice(f.Config.Files, []string{"config"}, "List of the config file names. All viper supported extensions can be used.")
 
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.Address, "http://127.0.0.1:8000", "Address used to make the server listen to.")
+	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.MetricsAddress, "http://127.0.0.1:8000", "Optional alternate address to expose metrics on at /metrics. Leave blank to use the address above.")
 	newCommand.cobraCommand.PersistentFlags().Bool(f.Server.Log.Access, false, "Whether to emit logs for each requested route.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.CaFile, "", "File path of the TLS root CA file, if any.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.CrtFile, "", "File path of the TLS public key file, if any.")
@@ -105,6 +106,9 @@ func (c *command) Execute(cmd *cobra.Command, args []string) {
 		serverConfig.LogAccess = c.viper.GetBool(f.Server.Log.Access)
 		if serverConfig.ListenAddress == "" {
 			serverConfig.ListenAddress = c.viper.GetString(f.Server.Listen.Address)
+		}
+		if serverConfig.ListenMetricsAddress == "" {
+			serverConfig.ListenMetricsAddress = c.viper.GetString(f.Server.Listen.MetricsAddress)
 		}
 		if serverConfig.TLSCAFile == "" {
 			serverConfig.TLSCAFile = c.viper.GetString(f.Server.TLS.CaFile)

--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -60,7 +60,7 @@ func New(config Config) (Command, error) {
 	newCommand.cobraCommand.PersistentFlags().StringSlice(f.Config.Files, []string{"config"}, "List of the config file names. All viper supported extensions can be used.")
 
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.Address, "http://127.0.0.1:8000", "Address used to make the server listen to.")
-	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.MetricsAddress, "", "Optional alternate address to expose metrics on at /metrics. Leave blank to use the address above.")
+	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.MetricsAddress, "", "Optional alternate address to expose metrics on at /metrics. Leave blank to use the default server (listen address above).")
 	newCommand.cobraCommand.PersistentFlags().Bool(f.Server.Log.Access, false, "Whether to emit logs for each requested route.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.CaFile, "", "File path of the TLS root CA file, if any.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.TLS.CrtFile, "", "File path of the TLS public key file, if any.")

--- a/command/daemon/flag/server/listen/listen.go
+++ b/command/daemon/flag/server/listen/listen.go
@@ -1,5 +1,6 @@
 package listen
 
 type Listen struct {
-	Address string
+	Address        string
+	MetricsAddress string
 }

--- a/server/server.go
+++ b/server/server.go
@@ -116,13 +116,13 @@ func New(config Config) (Server, error) {
 		if err != nil {
 			return nil, microerror.Maskf(invalidConfigError, err.Error())
 		}
-	}
 
-	// Check if the user supplied a https scheme for the optional metrics endpoint
-	// listener. Let them know that tls configuration for this endpoint is not yet
-	// implemented.
-	if listenMetricsURL.Scheme == "https" {
-		return nil, microerror.Maskf(invalidConfigError, "The optional metrics listener currently does not support tls configuration. Listening on https is thus disabled.")
+		// Check if the user supplied a https scheme for the optional metrics endpoint
+		// listener. Let them know that tls configuration for this endpoint is not yet
+		// implemented.
+		if listenMetricsURL.Scheme == "https" {
+			return nil, microerror.Maskf(invalidConfigError, "The optional metrics listener currently does not support tls configuration. Listening on https is thus disabled.")
+		}
 	}
 
 	newServer := &server{


### PR DESCRIPTION
This is my attempt at allowing the prometheus metrics endpoint to be available at a different port than the rest of the microservice.