### PR TITLE
Add option to enable debug server in http://127.0.0.1:6060/debug

### DIFF
--- a/command/daemon/command.go
+++ b/command/daemon/command.go
@@ -58,7 +58,7 @@ func New(config Config) (Command, error) {
 
 	newCommand.cobraCommand.PersistentFlags().StringSlice(f.Config.Dirs, []string{"."}, "List of config file directories.")
 	newCommand.cobraCommand.PersistentFlags().StringSlice(f.Config.Files, []string{"config"}, "List of the config file names. All viper supported extensions can be used.")
-
+	newCommand.cobraCommand.PersistentFlags().Bool(f.Server.Enable.Debug.Server, false, "Enable debug server at http://127.0.0.1:6060/debug.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.Address, "http://127.0.0.1:8000", "Address used to make the server listen to.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.MetricsAddress, "", "Optional alternate address to expose metrics on at /metrics. Leave blank to use the default server (listen address above).")
 	newCommand.cobraCommand.PersistentFlags().Bool(f.Server.Log.Access, false, "Whether to emit logs for each requested route.")
@@ -103,6 +103,7 @@ func (c *command) Execute(cmd *cobra.Command, args []string) {
 	{
 		serverConfig := c.serverFactory(c.viper).Config()
 
+		serverConfig.EnableDebugServer = c.viper.GetBool(f.Server.Enable.Debug.Server)
 		serverConfig.LogAccess = c.viper.GetBool(f.Server.Log.Access)
 		if serverConfig.ListenAddress == "" {
 			serverConfig.ListenAddress = c.viper.GetString(f.Server.Listen.Address)

--- a/command/daemon/flag/server/enable/debug/debug.go
+++ b/command/daemon/flag/server/enable/debug/debug.go
@@ -1,0 +1,5 @@
+package debug
+
+type Debug struct {
+	Server string
+}

--- a/command/daemon/flag/server/enable/enable.go
+++ b/command/daemon/flag/server/enable/enable.go
@@ -1,0 +1,7 @@
+package enable
+
+import "github.com/giantswarm/microkit/command/daemon/flag/server/enable/debug"
+
+type Enable struct {
+	Debug debug.Debug
+}

--- a/command/daemon/flag/server/server.go
+++ b/command/daemon/flag/server/server.go
@@ -1,12 +1,14 @@
 package server
 
 import (
+	"github.com/giantswarm/microkit/command/daemon/flag/server/enable"
 	"github.com/giantswarm/microkit/command/daemon/flag/server/listen"
 	"github.com/giantswarm/microkit/command/daemon/flag/server/log"
 	"github.com/giantswarm/microkit/command/daemon/flag/server/tls"
 )
 
 type Server struct {
+	Enable enable.Enable
 	Listen listen.Listen
 	Log    log.Log
 	TLS    tls.TLS

--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"net/url"
 	"strconv"
 	"strings"
@@ -37,6 +38,10 @@ type Config struct {
 	// endpoints registered that are listed in the endpoint collection.
 	Router *mux.Router
 
+	// EnableDebugServer boolean flag to enable debug server on
+	// http://127.0.0.1:6060/debug. This server is primarily used to expose
+	// net/http/pprof.Handler.
+	EnableDebugServer bool
 	// Endpoints is the server's configured list of endpoints. These are the
 	// custom endpoints configured by the client.
 	Endpoints []Endpoint
@@ -138,11 +143,12 @@ func New(config Config) (Server, error) {
 		listenMetricsUrl:  listenMetricsURL,
 		shutdownOnce:      sync.Once{},
 
-		endpoints:      config.Endpoints,
-		handlerWrapper: config.HandlerWrapper,
-		logAccess:      config.LogAccess,
-		requestFuncs:   config.RequestFuncs,
-		serviceName:    config.ServiceName,
+		enableDebugServer: config.EnableDebugServer,
+		endpoints:         config.Endpoints,
+		handlerWrapper:    config.HandlerWrapper,
+		logAccess:         config.LogAccess,
+		requestFuncs:      config.RequestFuncs,
+		serviceName:       config.ServiceName,
 		tlsCertFiles: tls.CertFiles{
 			RootCAs: []string{config.TLSCAFile},
 			Cert:    config.TLSCrtFile,
@@ -170,12 +176,13 @@ type server struct {
 	shutdownOnce      sync.Once
 
 	// Settings.
-	endpoints      []Endpoint
-	handlerWrapper func(h http.Handler) http.Handler
-	logAccess      bool
-	requestFuncs   []kithttp.RequestFunc
-	serviceName    string
-	tlsCertFiles   tls.CertFiles
+	enableDebugServer bool
+	endpoints         []Endpoint
+	handlerWrapper    func(h http.Handler) http.Handler
+	logAccess         bool
+	requestFuncs      []kithttp.RequestFunc
+	serviceName       string
+	tlsCertFiles      tls.CertFiles
 }
 
 func (s *server) Boot() {
@@ -279,6 +286,13 @@ func (s *server) Boot() {
 			// Register prometheus metrics endpoint to the same server as the rest of
 			// the endpoints.
 			s.router.Path("/metrics").Handler(promhttp.Handler())
+		}
+
+		if s.enableDebugServer {
+			go func() {
+				s.logger.Log("level", "debug", "message", "running debug server at http://127.0.0.1:6060/debug")
+				s.logger.Log("level", "debug", "message", "%#v", http.ListenAndServe("127.0.0.1:6060", pprof.Handler(s.serviceName)))
+			}()
 		}
 
 		// Register the router which has all of the configured custom endpoints

--- a/server/server.go
+++ b/server/server.go
@@ -293,7 +293,7 @@ func (s *server) Boot() {
 				s.logger.Log("level", "debug", "message", "running debug server at http://127.0.0.1:6060/debug")
 				// When net/http/pprof is imported, its init() registers /debug
 				// handles to DefaultServeMux automatically.
-				s.logger.Log("level", "debug", "message", "%#v", http.ListenAndServe("127.0.0.1:6060", nil))
+				s.logger.Log("level", "debug", "message", fmt.Sprintf("%#v", http.ListenAndServe("127.0.0.1:6060", nil)))
 			}()
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/pprof"
+	_ "net/http/pprof"
 	"net/url"
 	"strconv"
 	"strings"
@@ -291,7 +291,9 @@ func (s *server) Boot() {
 		if s.enableDebugServer {
 			go func() {
 				s.logger.Log("level", "debug", "message", "running debug server at http://127.0.0.1:6060/debug")
-				s.logger.Log("level", "debug", "message", "%#v", http.ListenAndServe("127.0.0.1:6060", pprof.Handler(s.serviceName)))
+				// When net/http/pprof is imported, its init() registers /debug
+				// handles to DefaultServeMux automatically.
+				s.logger.Log("level", "debug", "message", "%#v", http.ListenAndServe("127.0.0.1:6060", nil))
 			}()
 		}
 


### PR DESCRIPTION
This change adds option to enable `net/http/pprof` debug server for localhost.
By enabling this in our services, we can debug performance issues on-demand.

Towards https://github.com/giantswarm/giantswarm/issues/4063