### PR TITLE
Add deep validation for unknown attributes.

### DIFF
--- a/validator/unknown_attribute.go
+++ b/validator/unknown_attribute.go
@@ -49,6 +49,16 @@ func UnknownAttribute(received, expected map[string]interface{}) error {
 		var found bool
 
 		for e := range expected {
+			_, eIsMapStringInterface := expected[e].(map[string]interface{})
+			_, rIsMapStringInterface := received[r].(map[string]interface{})
+
+			if eIsMapStringInterface && rIsMapStringInterface {
+				err := UnknownAttribute(received[r].(map[string]interface{}), expected[e].(map[string]interface{}))
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+
 			if e == r {
 				found = true
 				break

--- a/validator/unknown_attribute_test.go
+++ b/validator/unknown_attribute_test.go
@@ -47,6 +47,44 @@ func Test_UnknownAttribute(t *testing.T) {
 			ErrorAttribute: "baz",
 			ErrorMatcher:   IsUnknownAttribute,
 		},
+		{
+			Received:       map[string]interface{}{"nested": map[string]interface{}{"attribute": "yes"}},
+			Expected:       map[string]interface{}{"nested": map[string]interface{}{"attribute": "yes"}},
+			ErrorAttribute: "",
+			ErrorMatcher:   nil,
+		},
+		{
+			Received: map[string]interface{}{
+				"nested": map[string]interface{}{
+					"unknown_attribute": "oh no",
+				},
+			},
+			Expected: map[string]interface{}{
+				"nested": map[string]interface{}{
+					"known_attribute": "",
+				},
+			},
+			ErrorAttribute: "unknown_attribute",
+			ErrorMatcher:   IsUnknownAttribute,
+		},
+		{
+			Received: map[string]interface{}{
+				"deeply": map[string]interface{}{
+					"nested": map[string]interface{}{
+						"unknown_attribute": true,
+					},
+				},
+			},
+			Expected: map[string]interface{}{
+				"deeply": map[string]interface{}{
+					"nested": map[string]interface{}{
+						"known_attribute": "",
+					},
+				},
+			},
+			ErrorAttribute: "unknown_attribute",
+			ErrorMatcher:   IsUnknownAttribute,
+		},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
This will let me validate the more complex structures, for example:

```
{
  "spec": { 
    "version":"1.0.0"
  }
}
```

This helps us let users know when they provide attributes in their JSON body that aren't actually editable.

For example, if they provide a "spec.name" field, then I want to throw an UnknownAttribute error. With the current implementation that's not possible, since it doesn't check further than `spec`.