### PR TITLE
Exposes version

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -21,6 +21,7 @@ type Config struct {
 	GitCommit      string
 	Name           string
 	Source         string
+	Version        string
 	VersionBundles []versionbundle.Bundle
 	Viper          *viper.Viper
 }
@@ -54,6 +55,7 @@ func New(config Config) (Command, error) {
 			GitCommit:      config.GitCommit,
 			Name:           config.Name,
 			Source:         config.Source,
+			Version:        config.Version,
 			VersionBundles: config.VersionBundles,
 		}
 

--- a/command/version/command.go
+++ b/command/version/command.go
@@ -16,6 +16,7 @@ type Config struct {
 	GitCommit      string
 	Name           string
 	Source         string
+	Version        string
 	VersionBundles []versionbundle.Bundle
 }
 
@@ -32,6 +33,9 @@ func New(config Config) (Command, error) {
 	if config.Source == "" {
 		return nil, microerror.Maskf(invalidConfigError, "source must not be empty")
 	}
+	if config.Version == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Version must not be empty", config)
+	}
 
 	newCommand := &command{
 		cobraCommand: nil,
@@ -43,6 +47,7 @@ func New(config Config) (Command, error) {
 		GoVersion:      runtime.Version(),
 		OS:             runtime.GOOS,
 		Arch:           runtime.GOARCH,
+		Version:        config.Version,
 		VersionBundles: config.VersionBundles,
 	}
 
@@ -66,6 +71,7 @@ type command struct {
 	GoVersion      string                 `json:"goVersion" yaml:"goVersion"`
 	OS             string                 `json:"os" yaml:"os"`
 	Arch           string                 `json:"arch" yaml:"arch"`
+	Version        string                 `json:"version" yaml:"version"`
 	VersionBundles []versionbundle.Bundle `json:"versionBundles" yaml:"versionBundles"`
 }
 

--- a/command/version/command.go
+++ b/command/version/command.go
@@ -22,16 +22,16 @@ type Config struct {
 
 func New(config Config) (Command, error) {
 	if config.Description == "" {
-		return nil, microerror.Maskf(invalidConfigError, "description commit must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.Description must not be empty", config)
 	}
 	if config.GitCommit == "" {
-		return nil, microerror.Maskf(invalidConfigError, "git commit must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.GitCommit must not be empty", config)
 	}
 	if config.Name == "" {
-		return nil, microerror.Maskf(invalidConfigError, "name must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.Name must not be empty", config)
 	}
 	if config.Source == "" {
-		return nil, microerror.Maskf(invalidConfigError, "source must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.Source must not be empty", config)
 	}
 	if config.Version == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Version must not be empty", config)


### PR DESCRIPTION
Towards: giantswarm/giantswarm#6559

Exposes version in version command.
/!\ This is a breaking change as it will requires to provide `Version` when creating a new version command.